### PR TITLE
Assert rotation precision before translation during tests

### DIFF
--- a/tests/registration/imregdft_2d_test.py
+++ b/tests/registration/imregdft_2d_test.py
@@ -47,8 +47,8 @@ def test_registration_2d_imregdft2d_register_with_empty_image(image: Image2D) ->
     registration = ImregDft2DRegistration()
     result = registration.register(image.data, np.zeros_like(image.data))
 
-    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.rotation == approx_rotation(0)
+    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.scale == pytest.approx(1)
 
 
@@ -61,8 +61,8 @@ def test_registration_2d_imregdft2d_equal_input_images(image: Image2D) -> None:
     """
     result = ImregDft2DRegistration().register(image.data, image.copy().data)
 
-    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.rotation == approx_rotation(0)
+    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.scale == pytest.approx(1)
 
 
@@ -87,6 +87,6 @@ def test_registration_2d_imregdft2d_rotation_shift(
     registration = ImregDft2DRegistration()
     result = registration.register(image.data, image_transformed.data)
 
-    assert euclidean(shifts, result.transformation.translation) <= 0.005 * image_size
     assert result.transformation.rotation == approx_rotation(rotation, abs=0.22)
+    assert euclidean(shifts, result.transformation.translation) <= 0.005 * image_size
     assert result.transformation.scale == pytest.approx(1, abs=0.005)  # 0.5%

--- a/tests/registration/keller_2d_test.py
+++ b/tests/registration/keller_2d_test.py
@@ -58,8 +58,8 @@ def test_registration_2d_keller2d_register_with_empty_image(
     )
     result = registration.register(image.data, np.zeros_like(image.data))
 
-    assert result.transformation.translation == (0.0, 0.0)
     assert result.transformation.rotation == 0
+    assert result.transformation.translation == (0.0, 0.0)
     assert result.transformation.scale is None  # Scaling is not supported.
 
 
@@ -83,8 +83,8 @@ def test_registration_2d_keller2d_equal_input_images(
     )
     result = registration.register(image.data, image.copy().data)
 
-    assert result.transformation.translation == (0.0, 0.0)
     assert result.transformation.rotation == approx_rotation(0)
+    assert result.transformation.translation == (0.0, 0.0)
     assert result.transformation.scale is None  # Scaling is not supported.
 
 
@@ -130,6 +130,6 @@ def test_registration_2d_keller2d_rotation_shift(
 
     # Tested with 64x64 F16 iamge from ADF paper.
 
-    assert result.transformation.translation == shifts
     assert result.transformation.rotation == approx_rotation(rotation, abs=rotation_tol)
+    assert result.transformation.translation == shifts
     assert result.transformation.scale is None  # Scaling is not supported.

--- a/tests/registration/keller_3d_test.py
+++ b/tests/registration/keller_3d_test.py
@@ -47,8 +47,8 @@ def test_registration_3d_keller3d_register_with_empty_image(
     registration = Keller3DRegistration(debug=debug)
     result = registration.register(image.data, np.zeros_like(image.data))
 
-    assert result.transformation.translation == (0.0,) * 3
     assert result.transformation.rotation == (0.0,) * 3
+    assert result.transformation.translation == (0.0,) * 3
     assert result.transformation.scale is None  # Scaling is not supported.
 
 
@@ -65,8 +65,8 @@ def test_registration_3d_keller3d_equal_input_images(
 
     result = registration.register(image.data, image.copy().data)
 
-    assert result.transformation.translation == (0.0,) * 3
     assert result.transformation.rotation == (0.0,) * 3
+    assert result.transformation.translation == (0.0,) * 3
     assert result.transformation.scale is None  # Scaling is not supported.
 
 

--- a/tests/registration/rotation_axis_3d_test.py
+++ b/tests/registration/rotation_axis_3d_test.py
@@ -64,8 +64,8 @@ def test_registration_3d_rotationaxis3d_register_with_empty_image(
     )
     result = registration.register(image.data, np.zeros_like(image.data))
 
-    assert result.transformation.translation == (0.0, 0.0, 0.0)
     assert result.transformation.rotation == approx_rotation((0.0, 0.0, 0.0))
+    assert result.transformation.translation == (0.0, 0.0, 0.0)
     assert result.transformation.scale is None  # Scaling is not supported.
 
 
@@ -96,12 +96,11 @@ def test_registration_3d_rotationaxis3d_equal_input_images(
     )
     result = registration.register(image.data, image.copy().data)
 
-    assert result.transformation.translation == (0.0, 0.0, 0.0)
     assert result.transformation.rotation == approx_rotation((0.0, 0.0, 0.0))
+    assert result.transformation.translation == (0.0, 0.0, 0.0)
     assert result.transformation.scale is None  # Scaling is not supported.
 
 
-# NOTE: Rotation with angle '5' works worse with normalization enabled.
 @pytest.mark.parametrize("shift_z", TEST_SHIFTS_3D, ids=lambda x: f"tz={x}")
 @pytest.mark.parametrize("shift_y", TEST_SHIFTS_3D, ids=lambda x: f"ty={x}")
 @pytest.mark.parametrize("shift_x", TEST_SHIFTS_3D, ids=lambda x: f"tx={x}")
@@ -148,6 +147,6 @@ def test_registration_3d_rotationaxis3d_rotation_shift(
     rotation_tol = factor * np.rad2deg(np.arctan(1 / image_size))
 
     # TODO: Only validate single axis rotation (and/or quaternion distance).
-    assert result.transformation.translation == shifts  # Shifts are exact here.
     assert result.transformation.rotation == approx_rotation(degrees, abs=rotation_tol)
+    assert result.transformation.translation == shifts  # Shifts are exact here.
     assert result.transformation.scale is None  # Scaling is not supported.

--- a/tests/registration/scikit_2d_test.py
+++ b/tests/registration/scikit_2d_test.py
@@ -43,8 +43,8 @@ def test_registration_2d_scikit2d_register_with_empty_image(image: Image2D) -> N
     registration = Scikit2DRegistration()
     result = registration.register(image.data, np.zeros_like(image.data))
 
-    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.rotation == approx_rotation(0)
+    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.scale == pytest.approx(1)
 
 
@@ -57,8 +57,8 @@ def test_registration_2d_scikit2d_equal_input_images(image: Image2D) -> None:
     """
     result = Scikit2DRegistration().register(image.data, image.copy().data)
 
-    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.rotation == approx_rotation(0)
+    assert result.transformation.translation == pytest.approx((0.0,) * 2)
     assert result.transformation.scale == pytest.approx(1)
 
 
@@ -86,8 +86,8 @@ def test_registration_2d_scikit2d_rotation_shift_scale(
     result = registration.register(image.data, image_transformed.data)
 
     # With scale=1.0, rotation works with abs=1, shifts with abs=1, and scale with 0.01.
-    assert result.transformation.translation == pytest.approx(shifts, abs=3)
     assert result.transformation.rotation == approx_rotation(rotation, abs=1.2)
+    assert result.transformation.translation == pytest.approx(shifts, abs=3)
     assert result.transformation.scale == pytest.approx(scale, abs=0.016)  # 1.6%
 
 
@@ -136,6 +136,6 @@ def test_registration_2d_scikit2d_scikit_image_example() -> None:
     )
     result = registration.register(image.data, image_transformed.data)
 
-    assert result.transformation.translation == shifts
     assert result.transformation.rotation == approx_rotation(rotation, abs=0.1)
+    assert result.transformation.translation == shifts
     assert result.transformation.scale == pytest.approx(scale, abs=0.001)


### PR DESCRIPTION
The rotation precision should be asserted before the translation as for these methods, the translation is dependent on the correct rotation estimation. Before, it was not clear whether a failing translation would be due to wrong translation estimation or failed rotation estimation.