### PR TITLE
Update usage of deprecated pytransform3d function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "numpy",
   "scipy<2", # imreg_dft uses deprecated functions which are to be removed in SciPy 2.
   "scikit-image",
-  "pytransform3d",
+  "pytransform3d>=3.8.0", # 'pytransform3d.rotations.norm_euler'
   "imreg-dft",
   "tqdm",
   "matplotlib",

--- a/src/ndimreg/benchmark/runner.py
+++ b/src/ndimreg/benchmark/runner.py
@@ -127,7 +127,7 @@ class BenchmarkRunner:
                 rotation_angle_in, axis=rotation_axis, dim=dim
             )
             rotation_euler_in = tuple(
-                np.rad2deg(pr.intrinsic_euler_xyz_from_active_matrix(rotation))
+                np.rad2deg(pr.euler_from_matrix(rotation, 0, 1, 2, extrinsic=False))
             )
             axis_kwargs = {"axis": rotation_axis}
 
@@ -242,7 +242,7 @@ class BenchmarkRunner:
                 # rotation around a single axis.
                 # TODO: Move this to result class instead.
                 axis_angle = pr.axis_angle_from_matrix(
-                    pr.active_matrix_from_intrinsic_euler_xyz(rotation_euler_out)
+                    pr.matrix_from_euler(rotation_euler_out, 0, 1, 2, extrinsic=False)
                 )
                 axis, angle = axis_angle[:3], axis_angle[3]
                 # TODO: Description.

--- a/src/ndimreg/registration/keller_3d.py
+++ b/src/ndimreg/registration/keller_3d.py
@@ -190,9 +190,11 @@ class Keller3DRegistration(BaseRegistration):
 
         angle_result = self.__rotation_angle_registration.register(*tilde_images)
         z_rot = angle_result.transformation.rotation
-        rot_mat_z_axis = pr.active_matrix_from_intrinsic_euler_xyz(np.deg2rad(z_rot))
+        rot_mat_z_axis = pr.matrix_from_euler(
+            np.deg2rad(z_rot), 0, 1, 2, extrinsic=False
+        )
         matrix = rot_mat_r_tilde @ inv(rot_mat_z_axis) @ inv(rot_mat_r_tilde)
-        angles = np.rad2deg(pr.intrinsic_euler_xyz_from_active_matrix(inv(matrix)))
+        angles = np.rad2deg(pr.euler_from_matrix(inv(matrix), 0, 1, 2, extrinsic=False))
         logger.debug(f"Recovered angles: [{', '.join(f'{x:.2f}' for x in angles)}]")
 
         moving_rotated = self._transform(moving, rotation=matrix)

--- a/src/ndimreg/registration/rotation_axis_3d.py
+++ b/src/ndimreg/registration/rotation_axis_3d.py
@@ -116,7 +116,9 @@ class RotationAxis3DRegistration(BaseRegistration):
 
         basis = ROTATION_BASIS[self.__rotation_axis]
         rotation_matrix = pr.active_matrix_from_angle(basis, rotation)
-        angles = np.rad2deg(pr.intrinsic_euler_xyz_from_active_matrix(rotation_matrix))
+        angles = np.rad2deg(
+            pr.euler_from_matrix(rotation_matrix, 0, 1, 2, extrinsic=False)
+        )
 
         tform = Transformation3D(translation=shift, rotation=tuple(angles))
         return ResultInternal3D(

--- a/src/ndimreg/transform/transformation.py
+++ b/src/ndimreg/transform/transformation.py
@@ -336,7 +336,7 @@ def __build_rotation_matrix(
         # We also norm the Euler angles just to be sure, this might not
         # be absolutely necessary though.
         euler = pr.norm_euler(np.deg2rad(rotation) if degrees else rotation, 0, 1, 2)
-        matrix = pr.active_matrix_from_intrinsic_euler_xyz(euler)
+        matrix = pr.matrix_from_euler(euler, 0, 1, 2, extrinsic=False)
 
     elif len(rotation) == 4:
         matrix = pr.matrix_from_quaternion(rotation)

--- a/tests/registration/rotation_axis_3d_test.py
+++ b/tests/registration/rotation_axis_3d_test.py
@@ -141,7 +141,9 @@ def test_registration_3d_rotationaxis3d_rotation_shift(
     # then converted to the output Euler angle convention.
     basis = {0: 0, 1: 2, 2: 1}[AXIS_MAPPING[axis][1]]
     rotation_matrix = pr.active_matrix_from_angle(basis, np.deg2rad(-rotation))
-    degrees = np.rad2deg(pr.intrinsic_euler_xyz_from_active_matrix(rotation_matrix))
+    degrees = np.rad2deg(
+        pr.euler_from_matrix(rotation_matrix, 0, 1, 2, extrinsic=False)
+    )
 
     factor = 1.0 if rotation_normalization else 1.1
     rotation_tol = factor * np.rad2deg(np.arctan(1 / image_size))


### PR DESCRIPTION
pytransform3d has deprecated various conversions between matrices and Euler angles.

This PR addresses that and also sets the known minimum requirement on the pytransform3d package to `3.8.0` due to the usage of `pytransform3d.rotations.norm_euler()`.