### PR TITLE
Update 3D normalization approach and allow axis selection for internal axis alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-...
+### Added
+
+- Add rotation alignment axis for 3D registration method.
+
+### Changed
+
+- **BREAKING**: Use Z-axis as default angle alignment axis for
+  **Keller3DRegistration** registration method.
 
 ## [0.2.0] - 2025-03-14
 


### PR DESCRIPTION
This allows to select the internal axis for the rotation angle estimation. It slightly affects the precision and therefore should be configurable.
Previously, the last axis (X-axis) has been used as hard-coded default. This now defaults to the first axis which is defined as the Z-axis.