### PR TITLE
Use updated function name array_namespace() to retrieve array namespace

### DIFF
--- a/src/ndimreg/fusion/merge.py
+++ b/src/ndimreg/fusion/merge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from typing_extensions import override
 
 from .base import BaseFusion
@@ -41,7 +41,7 @@ class MergeFusion(BaseFusion):
 
     @override
     def _fuse(self, *images: NDArray, **_kwargs: Any) -> NDArray:
-        xp = get_namespace(*images)
+        xp = array_namespace(*images)
 
         alpha = self.__alpha or 1 / len(images)
         data = xp.sum(xp.asarray(images) * alpha, 0)

--- a/src/ndimreg/image/image.py
+++ b/src/ndimreg/image/image.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import skimage
 import skimage.io as skio
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from loguru import logger
 
 from ndimreg.transform import get_center, resize, rotate_axis, transform
@@ -498,4 +498,4 @@ class Image(ABC):
 
     @property
     def __namespace(self) -> ModuleType:
-        return get_namespace(self.data)
+        return array_namespace(self.data)

--- a/src/ndimreg/processor/rescale.py
+++ b/src/ndimreg/processor/rescale.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from typing_extensions import override
 
 from ndimreg.utils.image_operations import rescale_intensity
@@ -26,7 +26,7 @@ class RescaleProcessor(BaseDataProcessor):
     def process(self, *data: NDArray) -> list[NDArray]:
         """TODO."""
         if self.group:
-            xp = get_namespace(*data)
+            xp = array_namespace(*data)
             in_range = xp.min([*data]), xp.max([*data])
         else:
             in_range = "image"

--- a/src/ndimreg/processor/resize.py
+++ b/src/ndimreg/processor/resize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from typing_extensions import override
 
 from ndimreg.utils.image_operations import rescale_intensity
@@ -25,7 +25,7 @@ class ResizeProcessor(BaseDataProcessor):
     def process(self, *data: NDArray) -> list[NDArray]:
         """TODO."""
         if self.group:
-            xp = get_namespace(*data)
+            xp = array_namespace(*data)
             in_range = xp.min([*data]), xp.max([*data])
         else:
             in_range = "image"

--- a/src/ndimreg/processor/threshold.py
+++ b/src/ndimreg/processor/threshold.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from typing_extensions import override
 
 from .base import BaseDataProcessor
@@ -50,7 +50,7 @@ class ThresholdCutFilter(BaseDataProcessor):
 
     def __process_group(self, *data: NDArray) -> list[NDArray]:
         """TODO."""
-        xp = get_namespace(*data)
+        xp = array_namespace(*data)
 
         match self.__cval:
             case "min":

--- a/src/ndimreg/registration/base.py
+++ b/src/ndimreg/registration/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from loguru import logger
 from scipy.fft import fftshift
 
@@ -181,7 +181,7 @@ class BaseRegistration(ABC, Registration):
         suffix: str = "",
         copy: bool = True,
     ) -> list[RegistrationDebugImage]:
-        xp = get_namespace(*images)
+        xp = array_namespace(*images)
         logger.debug(f"Using namespace for debug images: {xp.__name__}")
 
         images_corrected = (

--- a/src/ndimreg/registration/imregdft_2d.py
+++ b/src/ndimreg/registration/imregdft_2d.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from array_api_compat import get_namespace, is_cupy_namespace
+from array_api_compat import array_namespace, is_cupy_namespace
 from imreg_dft.imreg import _similarity
 from loguru import logger
 from typing_extensions import override
@@ -123,7 +123,7 @@ class ImregDft2DRegistration(BaseRegistration):
     def _register(
         self, fixed: NDArray, moving: NDArray, **_kwargs: Any
     ) -> ResultInternal2D:
-        if is_cupy_namespace(get_namespace(fixed, moving)):
+        if is_cupy_namespace(array_namespace(fixed, moving)):
             msg = f"Registration method {self.name} does not support GPU device (CuPy), transfering data to CPU (NumPy)"
             logger.warning(msg)
             fixed, moving = to_numpy_arrays(fixed, moving)

--- a/src/ndimreg/registration/keller_2d.py
+++ b/src/ndimreg/registration/keller_2d.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from typing_extensions import override
 
 from ndimreg.processor import GrayscaleProcessor2D
@@ -119,7 +119,7 @@ class Keller2DRegistration(BaseRegistration):
         self, fixed: NDArray, moving: NDArray, **_kwargs: Any
     ) -> ResultInternal2D:
         images = (fixed, moving)
-        xp = get_namespace(*images)
+        xp = array_namespace(*images)
 
         rotation, debug_images = _resolve_rotation(
             images,

--- a/src/ndimreg/registration/keller_2d_utils.py
+++ b/src/ndimreg/registration/keller_2d_utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Annotated, Literal, TypeVar, overload
 
 import numpy as np
 import pytransform3d.rotations as pr
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from loguru import logger
 from matplotlib import pyplot as plt
 from matplotlib.patches import Rectangle
@@ -135,7 +135,7 @@ def __omega_indices(omega: OmegaArray) -> tuple[int, int, int]:
 
 
 def __index_default(omega: OmegaArray) -> int:
-    return get_namespace(omega).argmin(omega).item()
+    return array_namespace(omega).argmin(omega).item()
 
 
 @overload

--- a/src/ndimreg/registration/keller_3d.py
+++ b/src/ndimreg/registration/keller_3d.py
@@ -10,7 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pytransform3d.rotations as pr
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from matplotlib.patches import Circle
 from numpy.linalg import inv
 from ppftpy import ppft3, rppft3
@@ -164,7 +164,7 @@ class Keller3DRegistration(BaseRegistration):
         self, fixed: NDArray, moving: NDArray, **_kwargs: Any
     ) -> ResultInternal3D:
         images = (fixed, moving)
-        xp = get_namespace(*images)
+        xp = array_namespace(*images)
 
         n = len(fixed)
         mask = _generate_mask(n, xp=xp) if self.__highpass_filter else False

--- a/src/ndimreg/registration/rotation_axis_3d.py
+++ b/src/ndimreg/registration/rotation_axis_3d.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 
 import numpy as np
 import pytransform3d.rotations as pr
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from typing_extensions import override
 
 from ndimreg.processor import GrayscaleProcessor3D
@@ -78,7 +78,7 @@ class RotationAxis3DRegistration(BaseRegistration):
     ) -> ResultInternal3D:
         # TODO: Support complex image input.
         images = (fixed, moving)
-        xp = get_namespace(*images)
+        xp = array_namespace(*images)
 
         rotation, debug_images = _resolve_rotation(
             (xp.moveaxis(im, SRC, DEST[self.__rotation_axis]) for im in images),

--- a/src/ndimreg/registration/scikit_2d.py
+++ b/src/ndimreg/registration/scikit_2d.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import numpy as np
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from loguru import logger
 from pytransform3d.rotations import norm_angle
 from scipy import fft
@@ -100,7 +100,7 @@ class Scikit2DRegistration(BaseRegistration):
     def _register(
         self, fixed: NDArray, moving: NDArray, **_kwargs: Any
     ) -> ResultInternal2D:
-        xp = get_namespace(fixed, moving)
+        xp = array_namespace(fixed, moving)
         fft_images = (xp.abs(fft.fftshift(fft.fft2(im))) for im in (fixed, moving))
         shape = fixed.shape
         radius = shape[0] // 8

--- a/src/ndimreg/registration/shift_resolver.py
+++ b/src/ndimreg/registration/shift_resolver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from loguru import logger
 from scipy import fft
 
@@ -49,7 +49,7 @@ def resolve_shift(
     # TODO: Test whether rotating FFT is equal to FFT2 of rotated image.
     # TODO: Test whether 'real' FFT can be used instead.
     # TODO: Use fallback instance for translation registration method.
-    xp = get_namespace(fixed, moving)
+    xp = array_namespace(fixed, moving)
 
     with AutoScipyFftBackend(xp):
         fixed_fft = fft.fftn(fixed)

--- a/src/ndimreg/transform/transformation.py
+++ b/src/ndimreg/transform/transformation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytransform3d.rotations as pr
-from array_api_compat import get_namespace
+from array_api_compat import array_namespace
 from loguru import logger
 
 from ndimreg.utils import array_to_shape, log_time
@@ -102,7 +102,7 @@ def transform(  # noqa: PLR0913
     }
 
     # NOTE: 2D transformations might need to be inverted.
-    xp = get_namespace(data)
+    xp = array_namespace(data)
     tform = xp.asarray(np.linalg.inv(transformation) if inverse else transformation)
     transformed_data = (
         xp.stack(

--- a/src/ndimreg/utils/fft.py
+++ b/src/ndimreg/utils/fft.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from array_api_compat import get_namespace, is_cupy_namespace
+from array_api_compat import array_namespace, is_cupy_namespace
 from scipy import fft
 
 try:
@@ -70,7 +70,7 @@ class AutoScipyFftBackend:
     @classmethod
     def from_array(cls, *arrays: NDArray) -> Self:
         """TODO."""
-        return cls(get_namespace(*arrays))
+        return cls(array_namespace(*arrays))
 
     def __enter__(self) -> Any:
         """TODO."""

--- a/src/ndimreg/utils/image_operations.py
+++ b/src/ndimreg/utils/image_operations.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from array_api_compat import get_namespace, is_cupy_array
+from array_api_compat import array_namespace, is_cupy_array
 from loguru import logger
 from scipy.ndimage import affine_transform as at_cpu
 from skimage.color import rgb2gray as r2g_cpu
@@ -99,7 +99,7 @@ def affine_transform(image: NDArray, inverse_map: NDArray, **kwargs: Any) -> NDA
     # We need to transfer the transformed data back to the original
     # image's backend in case of using the CPU-based transform on
     # data that uses it as fallback.
-    xp = get_namespace(image)
+    xp = array_namespace(image)
     return xp.asarray(affine_transform(image, inverse_map, **kwargs))
 
 
@@ -129,7 +129,7 @@ def resize_local_mean(
     **kwargs: Any,
 ) -> NDArray:
     """TODO."""
-    xp = get_namespace(image)
+    xp = array_namespace(image)
 
     if is_cupy_array(image) and cp:
         if rlm_gpu:
@@ -148,7 +148,7 @@ def warp_polar(
     image: NDArray, center: tuple[int, int] | None = None, **kwargs: Any
 ) -> NDArray:
     """TODO."""
-    xp = get_namespace(image)
+    xp = array_namespace(image)
 
     if is_cupy_array(image) and cp:
         if wp_gpu:
@@ -165,7 +165,7 @@ def warp_polar(
 
 def rgb2gray(rgb: NDArray, **kwargs: Any) -> NDArray:
     """TODO."""
-    xp = get_namespace(rgb)
+    xp = array_namespace(rgb)
 
     if is_cupy_array(rgb) and cp:
         if r2g_gpu:
@@ -186,7 +186,7 @@ def rescale_intensity(
     out_range: str | tuple[float, float] = "dtype",
 ) -> NDArray:
     """TODO."""
-    xp = get_namespace(data)
+    xp = array_namespace(data)
 
     if is_cupy_array(data) and cp:
         if ri_gpu:
@@ -208,7 +208,7 @@ def difference_of_gaussians(
     **kwargs: Any,
 ) -> NDArray:
     """TODO."""
-    xp = get_namespace(image)
+    xp = array_namespace(image)
 
     if is_cupy_array(image) and cp:
         if dog_gpu:
@@ -230,7 +230,7 @@ def window(
     warp_kwargs: Any | None = None,
 ) -> NDArray:
     """TODO."""
-    xp = get_namespace(image)
+    xp = array_namespace(image)
 
     if is_cupy_array(image) and cp:
         if w_gpu:


### PR DESCRIPTION
This replaces the alias `get_namespace()` with the new function `array_namespace()`.